### PR TITLE
Add option to let pandas interpret empty strings as nan

### DIFF
--- a/pandahouse/convert.py
+++ b/pandahouse/convert.py
@@ -58,7 +58,7 @@ def to_csv(df):
         return data
 
 
-def to_dataframe(lines, **kwargs):
+def to_dataframe(lines, keep_default_na=False, **kwargs):
     names = lines.readline().decode('utf-8').strip().split('\t')
     types = lines.readline().decode('utf-8').strip().split('\t')
 
@@ -77,7 +77,7 @@ def to_dataframe(lines, **kwargs):
 
     return pd.read_csv(lines, sep='\t', header=None, names=names, dtype=dtypes,
                        parse_dates=parse_dates, converters=converters,
-                       na_values=set(), keep_default_na=False, **kwargs)
+                       na_values=set(), keep_default_na=keep_default_na, **kwargs)
 
 
 def partition(df, chunksize=1000):


### PR DESCRIPTION
Currently, pandahouse fails (or rather pandas.read_csv) to parse float columns in ClickHouse if they have missing values.